### PR TITLE
Fixed a Typo and changed a Flavor declaration that does not exist

### DIFF
--- a/Assets/Python/RiseAndFall.py
+++ b/Assets/Python/RiseAndFall.py
@@ -1323,7 +1323,7 @@ class RiseAndFall:
 					sta.completeCollapse(iRome)
 			elif iCiv == iMamluks:
 				if pEgypt.isAlive():
-					sta.completCollapse(iEgypt)
+					sta.completeCollapse(iEgypt)
 				
 		tCapital = Areas.getCapital(iCiv)
 				

--- a/Assets/XML/Civilizations/CIV4LeaderHeadInfos.xml
+++ b/Assets/XML/Civilizations/CIV4LeaderHeadInfos.xml
@@ -77821,7 +77821,7 @@
 					<iFlavor>8</iFlavor>
 				</Flavor>
 				<Flavor>
-					<FlavorType>FLAVOR_CIVICS</FlavorType>
+					<FlavorType>FLAVOR_ADMIN</FlavorType>
 					<iFlavor>2</iFlavor>
 				</Flavor>
 			</Flavors>


### PR DESCRIPTION
Barghash changed from Flavor_Civics (which doesn't exist) to Flavor_Admin. This seems to match both with his historical achievements and what I assume you intended to accomplish using Flavor_Civics.

Fixed a typo in RiseAndFall.py where CompleteCollapse is instead spelled CompletCollapse