### PR TITLE
Enabled AI Harappa.

### DIFF
--- a/Assets/Python/EnabledCivs.py
+++ b/Assets/Python/EnabledCivs.py
@@ -17,7 +17,7 @@ dSpawnTypes = {
 iEgypt			: iConditionalSpawn,
 iChina			: iConditionalSpawn,
 iBabylonia		: iConditionalSpawn,
-iHarappa		: iNoSpawn,
+iHarappa		: iConditionalSpawn,
 iGreece			: iConditionalSpawn,
 iIndia			: iConditionalSpawn,
 iCarthage		: iConditionalSpawn,


### PR DESCRIPTION
When porting Merijn's EnabledCivs.py I forgot 1.15 didn't have Harappa as an AI Civ. This fixes that.