### PR TITLE
Egypt keeps resurrecting and blocking the Mamluks' initial spawn.

### DIFF
--- a/Assets/Python/Consts.py
+++ b/Assets/Python/Consts.py
@@ -465,7 +465,7 @@ iAztecs : iCivMexico,
 }
 
 tResurrectionIntervals = (
-[(900, 1300), (1800, 2020)], #Egypt
+[(1069, 1300), (1800, 2020)], #Egypt
 [(-3000, -500)], #Babylonia
 [],		# Harappa
 [(600, 2020)], #China


### PR DESCRIPTION
Moved the start of Egyptian resurrection period to 10 turns after the Mamluks' initial spawn.